### PR TITLE
Introduce `source` completion mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Fitten Code AI Programming Assistant for Neovim, helps you to use AI for automat
 - 🔎 Accept word with `Ctrl + ➡️`
 - ❄️ Undo accepted text
 - 🧨 Automatic scrolling when previewing or completing code
+- 🛰️ Run as a `nvim-cmp` source
 
 ## ⚡️ Requirements
 
@@ -47,12 +48,16 @@ use {
 
 ## ⚙️ Configuration
 
+### `updatetime`
+
 Set `updatetime` to a lower value to improve performance:
 
 ```lua
 -- Neovim default updatetime is 4000
 vim.opt.updatetime = 200
 ```
+
+### `defaults`
 
 **fittencode.nvim** comes with the following defaults:
 
@@ -67,10 +72,32 @@ vim.opt.updatetime = 200
     -- Enable inline code completion.
     enable = true,
   },
+  -- Set the mode of the completion.
+  -- Available options:
+  -- - 'inline' (default)
+  -- - 'source'
+  completion_mode = 'inline',
   log = {
     level = vim.log.levels.WARN,
   },
 }
+```
+
+### `source` mode
+
+- `inline` (default): Inline completion is enabled.
+- `source`: Run as a `nvim-cmp` source.
+
+```lua
+require('fittencode').setup({
+  completion_mode ='source',
+})
+require('cmp').setup({
+  sources = { name = 'fittencode', group_index = 1 },
+  mapping = {
+    ['<cr>'] = cmp.mapping.confirm({ behavior = cmp.ConfirmBehavior.Insert, select = true }),
+  }
+})
 ```
 
 ## 🚀 Usage

--- a/lua/fittencode/config.lua
+++ b/lua/fittencode/config.lua
@@ -42,6 +42,11 @@ M.options = {
     -- Use the Neovim Theme colors for syntax highlighting in the diff viewer.
     use_neovim_colors = false,
   },
+  -- Set the mode of the completion.
+  -- Available options:
+  -- - 'inline' (default)
+  -- - 'source'
+  completion_mode = 'inline',
   ---@class LogOptions
   log = {
     level = vim.log.levels.WARN,

--- a/lua/fittencode/engine.lua
+++ b/lua/fittencode/engine.lua
@@ -15,16 +15,19 @@ local cache = nil
 ---@class TaskScheduler
 local tasks = nil
 
+local inline_mode = true
+
 function M.setup()
   cache = SuggestionsCache:new()
   tasks = TaskScheduler:new()
   tasks:setup()
+  inline_mode = Config.options.completion_mode == 'inline'
 end
 
 -- Callback function for when suggestions is ready
 ---@param task_id integer
 ---@param suggestions Suggestions
-local function on_suggestions(task_id, suggestions)
+local function on_suggestions(task_id, suggestions, replaced_text)
   local row, col = Base.get_cursor()
   if not tasks:match_clean(task_id, row, col) then
     Log.debug('Completion request is outdated, discarding; task_id: {}, row: {}, col: {}', task_id, row, col)
@@ -34,8 +37,11 @@ local function on_suggestions(task_id, suggestions)
   Log.debug('Suggestions received; task_id: {}, suggestions: {}', task_id, suggestions)
 
   cache:update_pos(row, col)
-  cache:update_lines(suggestions)
-  View.render_virt_text(suggestions)
+  cache:update_lines(suggestions, replaced_text)
+
+  if inline_mode then
+    View.render_virt_text(suggestions)
+  end
 end
 
 -- Generate one stage completion
@@ -45,7 +51,7 @@ end
 ---@param row integer
 ---@param col integer
 ---@param force boolean|nil
-function M.generate_one_stage(row, col, force)
+function M.generate_one_stage(row, col, force, on_suggestions_ready)
   if not Sessions.ready_for_generate() then
     Log.debug('Not ready for generate')
     return
@@ -55,14 +61,19 @@ function M.generate_one_stage(row, col, force)
     return
   end
 
-  if Lsp.is_active() then
+  if inline_mode and Lsp.is_active() then
     Log.debug('LSP is active, cancel request generate one stage')
     return
   end
 
   local task_id = tasks:create(row, col)
   cache:flush()
-  Sessions.request_generate_one_stage(task_id, on_suggestions)
+  Sessions.request_generate_one_stage(task_id, function(id, suggestions, replaced_text)
+    on_suggestions(id, suggestions, replaced_text)
+    if on_suggestions_ready then
+      on_suggestions_ready(replaced_text)
+    end
+  end)
 end
 
 -- Check if there is any suggestions
@@ -219,7 +230,9 @@ end
 
 -- Reset suggestions cache and view
 function M.reset()
-  View.clear_virt_text()
+  if inline_mode then
+    View.clear_virt_text()
+  end
   cache:flush()
 end
 
@@ -249,6 +262,41 @@ function M.preflight()
     return false
   end
   return true
+end
+
+---@alias lsp.CompletionResponse lsp.CompletionList|lsp.CompletionItem[]
+
+local function is_spaces(line)
+  return line:find('^%s*$') ~= nil
+end
+
+local function is_last_char_space(line)
+  return string.sub(line, -1) == ' '
+end
+
+-- Convert suggestions to LSP items
+---@param suggestions string
+---@return lsp.CompletionResponse|nil
+function M.convert_to_lsp_completion_response(line, character, cursor_before_line, suggestions)
+  Log.debug('Need to convert suggestions to LSP items, suggestions: {}', suggestions)
+  suggestions = suggestions or cache.replaced_lines or ''
+  cursor_before_line = cursor_before_line or ''
+  local label = ''
+  if not is_last_char_space(cursor_before_line) then
+    suggestions = cursor_before_line .. suggestions
+  end
+  if #suggestions > 30 then
+    label = string.sub(suggestions, 1, 30)
+  else
+    label = suggestions
+  end
+  local items = {}
+  table.insert(items, {
+    label = label,
+    insertText = suggestions,
+    documentation = suggestions,
+  })
+  return { items = items, isIncomplete = false }
 end
 
 return M

--- a/lua/fittencode/init.lua
+++ b/lua/fittencode/init.lua
@@ -17,9 +17,14 @@ function M.setup(opts)
   require('fittencode.engine').setup()
   require('fittencode.color').setup_highlight()
   local Bindings = require('fittencode.bindings')
-  Bindings.setup_autocmds()
   Bindings.setup_commands()
-  Bindings.setup_keymaps()
+
+  if Config.options.completion_mode == 'inline' then
+    Bindings.setup_autocmds()
+    Bindings.setup_keymaps()
+  else
+    require('fittencode.lsp').resiter_source()
+  end
 
   -- Defer loading last session to avoid blocking initialization
   vim.defer_fn(function()

--- a/lua/fittencode/log.lua
+++ b/lua/fittencode/log.lua
@@ -87,6 +87,9 @@ local function expand_msg(msg, ...)
   msg = msg or ''
   local count = 0
   msg, count = msg:gsub('{}', '%%s')
+  if count == 0 and select('#', ...) == 0 then
+    return msg
+  end
   local args = vim.tbl_map(vim.inspect, { ... })
   if #args < count then
     for i = #args + 1, count do

--- a/lua/fittencode/lsp.lua
+++ b/lua/fittencode/lsp.lua
@@ -13,4 +13,13 @@ function M.is_active()
   return vim.tbl_count(entries) > 0
 end
 
+function M.resiter_source()
+  ---@type boolean, any
+  local ok, cmp = pcall(require, 'cmp')
+  if not ok then
+    return false
+  end
+  cmp.register_source('fittencode', require('fittencode.source'):new())
+end
+
 return M

--- a/lua/fittencode/source.lua
+++ b/lua/fittencode/source.lua
@@ -1,0 +1,47 @@
+local Base = require('fittencode.base')
+local Engine = require('fittencode.engine')
+local Log = require('fittencode.log')
+
+local source = {}
+
+function source:new(o)
+  o = o or {}
+  setmetatable(o, self)
+  self.__index = self
+  return o
+end
+
+function source:get_position_encoding_kind()
+  return 'utf-8'
+end
+
+-- function source:get_keyword_pattern()
+--   return '.*'
+-- end
+
+function source:get_trigger_characters()
+  return { ' ', '.', '#', '-' }
+end
+
+---Invoke completion (required).
+---@param params cmp.SourceCompletionApiParams
+---@param callback fun(response:lsp.CompletionResponse|nil)
+function source:complete(params, callback)
+  if not Engine.preflight() then
+    callback()
+    return
+  end
+  local row, col = Base.get_cursor()
+  Engine.generate_one_stage(row, col, true, function(suggestions)
+    local cursor_before_line = params.context.cursor_before_line
+    Log.debug('Cursor before line: {}', cursor_before_line)
+    local line = params.context.cursor.line
+    local character = params.context.cursor.character
+    Log.debug('Context cursor line: {}, character: {}', line, character)
+    local lsp_items = Engine.convert_to_lsp_completion_response(line, character, cursor_before_line, suggestions)
+    Log.debug('LSP items: {}', lsp_items)
+    callback(lsp_items)
+  end)
+end
+
+return source

--- a/lua/fittencode/source.lua
+++ b/lua/fittencode/source.lua
@@ -2,15 +2,37 @@ local Base = require('fittencode.base')
 local Engine = require('fittencode.engine')
 local Log = require('fittencode.log')
 
+-- types from nvim-cmp: `lua\cmp\types\cmp.lua`
+
+---@class FittenSource
+---@field trigger_characters string[]
 local source = {}
 
+---@return string[]
+local function get_trigger_characters()
+  local characters = {}
+  for i = 32, 126 do
+    characters[#characters + 1] = string.char(i)
+  end
+  characters[#characters + 1] = ' '
+  characters[#characters + 1] = '\n'
+  characters[#characters + 1] = '\r'
+  characters[#characters + 1] = '\r\n'
+  characters[#characters + 1] = '\t'
+  return characters
+end
+
+---@param o FittenSource
+---@return FittenSource
 function source:new(o)
   o = o or {}
+  o.trigger_characters = get_trigger_characters()
   setmetatable(o, self)
   self.__index = self
   return o
 end
 
+---@return string
 function source:get_position_encoding_kind()
   return 'utf-8'
 end
@@ -19,29 +41,36 @@ end
 --   return '.*'
 -- end
 
+---@return string[]
 function source:get_trigger_characters()
-  return { ' ', '.', '#', '-' }
+  return self.trigger_characters
 end
 
+local SOURCE_GENERATEONESTAGE_DEBOUNCE_TIME = 80
+
+---@type uv_timer_t
+local source_generate_one_stage_timer = nil
+
 ---Invoke completion (required).
----@param params cmp.SourceCompletionApiParams
+---@param request cmp.SourceCompletionApiParams
 ---@param callback fun(response:lsp.CompletionResponse|nil)
-function source:complete(params, callback)
+function source:complete(request, callback)
   if not Engine.preflight() then
     callback()
     return
   end
   local row, col = Base.get_cursor()
-  Engine.generate_one_stage(row, col, true, function(suggestions)
-    local cursor_before_line = params.context.cursor_before_line
-    Log.debug('Cursor before line: {}', cursor_before_line)
-    local line = params.context.cursor.line
-    local character = params.context.cursor.character
-    Log.debug('Context cursor line: {}, character: {}', line, character)
-    local lsp_items = Engine.convert_to_lsp_completion_response(line, character, cursor_before_line, suggestions)
-    Log.debug('LSP items: {}', lsp_items)
-    callback(lsp_items)
-  end)
+  Base.debounce(source_generate_one_stage_timer, function()
+    Engine.generate_one_stage(row, col, true, function(suggestions)
+      local cursor_before_line = request.context.cursor_before_line:sub(request.offset)
+      local line = request.context.cursor.line
+      local character = request.context.cursor.character
+      Log.debug('Request: {}', request)
+      local response = Engine.convert_to_lsp_completion_response(line, character, cursor_before_line, suggestions)
+      Log.debug('LSP CompletionResponse: {}', response)
+      callback(response)
+    end)
+  end, SOURCE_GENERATEONESTAGE_DEBOUNCE_TIME)
 end
 
 return source

--- a/lua/fittencode/suggestions_cache.lua
+++ b/lua/fittencode/suggestions_cache.lua
@@ -10,6 +10,7 @@ local SuggestionsCache = {}
 
 function SuggestionsCache.new()
   local self = setmetatable({}, { __index = SuggestionsCache })
+  self.replaced_lines = {}
   self.lines = {}
   self.pos = {}
   self.count = 0
@@ -24,10 +25,11 @@ end
 
 -- Update suggestions lines
 ---@param lines string[]|nil @suggestions lines
-function SuggestionsCache:update_lines(lines)
+function SuggestionsCache:update_lines(lines, replaced_lines)
   lines = lines or {}
   self.lines = lines
   self.count = vim.tbl_count(lines)
+  self.replaced_lines = replaced_lines or {}
 end
 
 -- Update suggestions start position


### PR DESCRIPTION
 Let `fittencode.nvim` serve as a source for `nvim-cmp`

- [x] Can work when  `['<cr>'] = cmp.mapping.confirm({ select = false }),`
- [ ] ~~Can work __without__  `['<cr>'] = cmp.mapping.confirm({ select = false }),`~~
    -  Require `confirm` to submit multiple lines of text at once 
- [x] Implementing through the `insertText`
- [ ] ~~Implementing through the `additionalTextEdits`?~~
    - Need update cursor
- [ ] ~~Can be triggered by any character~~
    - get_trigger_characters returns a set and cannot implement any key
- [x] Support any UTF-8 character
- [x] The `document` window supports syntax highlighting
- [x] Update document