### PR TITLE
Add highlighting for Icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,39 @@ require('cmp').setup({
 })
 ```
 
+### Highlighting & Icon
+FittenCode's cmp source now has a builtin highlight group CmpItemKindFittencode. To add an icon to FittenCode for lspkind, simply add FittenCode to your lspkind symbol map.
+
+``` lua
+-- lspkind.lua
+local lspkind = require("lspkind")
+lspkind.init({
+  symbol_map = {
+    FittenCode = "",
+  },
+})
+
+vim.api.nvim_set_hl(0, "CmpItemKindFittenCode", {fg ="#6CC644"})
+
+```
+Alternatively, you can add FittemCode to the lspkind symbol_map within the cmp format function.
+```lua
+-- cmp.lua
+cmp.setup {
+  ...
+  formatting = {
+    format = lspkind.cmp_format({
+      mode = "symbol",
+      max_width = 50,
+      symbol_map = { FittenCode = "" }
+    })
+  }
+  ...
+}
+```
+
+If you do not use lspkind, simply add the custom icon however you normally handle kind formatting and it will integrate as if it was any other normal lsp completion kind.
+
 ## 🚀 Usage
 
 - Optional parameters are enclosed in square brackets `[]`.

--- a/lua/fittencode/sources/cmp/source.lua
+++ b/lua/fittencode/sources/cmp/source.lua
@@ -87,6 +87,7 @@ local function convert_to_lsp_completion_response(line, character, cursor_before
     },
     insertTextMode = 1,
     cmp = {
+      kind_hl_group = 'CmpItemKindFittenCode',
       kind_text = 'FittenCode',
     },
   })


### PR DESCRIPTION
 为 nvim-cmp 提供彩色的图标
![image](https://github.com/user-attachments/assets/7f8821d1-87b1-4288-a286-238ebc5eef66)
