### PR TITLE
Add `blink.cmp` source support

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ use {
   source_completion = {
     -- Enable source completion.
     enable = true,
+    -- engine support nvim-cmp and blink.cmp
+    engine = "cmp" -- "cmp" | "blink"
     -- trigger characters for source completion.
     -- Available options:
     -- * A  list of characters like {'a', 'b', 'c', ...}
@@ -230,10 +232,14 @@ vim.opt.updatetime = 200
 
 ### `source` mode
 
+Now we can use `fittencode.nvim` as a `source` for `nvim-cmp` or `blink.cmp`
+
 ```lua
 require('fittencode').setup({
   completion_mode ='source',
 })
+
+-- cmp config
 require('cmp').setup({
   sources = { name = 'fittencode', group_index = 1 },
   mapping = {
@@ -241,12 +247,37 @@ require('cmp').setup({
     ['<c-y>'] = cmp.mapping.confirm({ behavior = cmp.ConfirmBehavior.Insert, select = false }),
   }
 })
+
+-- blink config
+{
+	"saghen/blink.cmp",
+  -- add fittencode.nvim to dependencies
+	dependencies = {
+		{ "luozhiya/fittencode.nvim" },
+	},
+	opts = {
+  -- add fittencode to sources
+		sources = {
+			completion = {
+				enabled_providers = { "lsp", "path", "snippets", "buffer", "fittencode" },
+			},
+
+    -- set custom providers with fittencode
+			providers = {
+				fittencode = {
+					name = "fittencode",
+					module = "fittencode.sources.blink",
+				},
+			},
+		},
+},
 ```
 
 ### Highlighting & Icon
+
 FittenCode's cmp source now has a builtin highlight group CmpItemKindFittencode. To add an icon to FittenCode for lspkind, simply add FittenCode to your lspkind symbol map.
 
-``` lua
+```lua
 -- lspkind.lua
 local lspkind = require("lspkind")
 lspkind.init({
@@ -258,7 +289,9 @@ lspkind.init({
 vim.api.nvim_set_hl(0, "CmpItemKindFittenCode", {fg ="#6CC644"})
 
 ```
+
 Alternatively, you can add FittemCode to the lspkind symbol_map within the cmp format function.
+
 ```lua
 -- cmp.lua
 cmp.setup {

--- a/lua/fittencode/config.lua
+++ b/lua/fittencode/config.lua
@@ -56,7 +56,7 @@ local M = {}
 
 ---@class FittenCodeSourceCompletionOptions
 ---@field enable boolean
----@field engine 'cmp' | 'coc' | 'ycm' | 'omni'
+---@field engine 'cmp' | 'coc' | 'ycm' | 'omni' | 'blink'
 ---@field trigger_chars string[]
 
 ---@class FittenCodeRestOptions
@@ -105,7 +105,7 @@ local defaults = {
       -- * Buffer without file extension
       -- * Buffer no filetype detected
       identify_buffer = true,
-    }
+    },
   },
   disable_specific_inline_completion = {
     -- Disable auto-completion for some specific file suffixes by entering them below
@@ -180,7 +180,7 @@ local defaults = {
       -- <= 1: percentage of the screen size
       -- >  1: number of lines/columns
       size = { width = 0.8, height = 0.8 },
-    }
+    },
   },
   -- Enable/Disable the default keymaps.
   use_default_keymaps = true,
@@ -202,7 +202,7 @@ local defaults = {
       ['C'] = 'copy_all_conversations',
       ['d'] = 'delete_conversation',
       ['D'] = 'delete_all_conversations',
-    }
+    },
   },
   -- Setting for source completion.
   ---@class SourceCompletionOptions

--- a/lua/fittencode/sources/blink/init.lua
+++ b/lua/fittencode/sources/blink/init.lua
@@ -1,0 +1,84 @@
+local Base = require('fittencode.base')
+local Config = require('fittencode.config')
+local Engine = require('fittencode.engines.inline')
+local Log = require('fittencode.log')
+local Sources = require('fittencode.sources')
+--@Class blink.cmp.Source
+local blink = {}
+
+-- Use `get_word` so that the word is the same as in `core.confirm`
+-- https://github.com/hrsh7th/nvim-cmp/pull/1860
+-- https://github.com/hrsh7th/nvim-cmp/pull/2002
+---@param suggestions string[]
+---@return lsp.CompletionResponse?
+local function convert_to_lsp_completion_response(line, character, suggestions)
+  -- cursor_before_line = cursor_before_line or ''
+  local LABEL_LIMIT = 80
+  local text = character .. table.concat(suggestions, '\n')
+  local first = character .. suggestions[1]
+  local label = (#first > LABEL_LIMIT or #suggestions > 1) and string.sub(first, 1, LABEL_LIMIT - 3) .. '...' or first
+  local items = {}
+  table.insert(items, {
+    kind = 'FittenCode',
+    label = label,
+    insertTextFormat = vim.lsp.protocol.InsertTextFormat.PlainText,
+    insertText = text,
+    description = '```' .. vim.bo.ft .. '\n' .. text .. '\n```',
+  })
+  return { items = items, is_incomplete_forward = false, is_incomplete_backward = false }
+end
+
+function blink:new()
+  return setmetatable({}, { __index = blink })
+end
+
+function blink:get_completions(context, callback)
+  local row, col = Base.get_cursor()
+  if not row or not col then
+    callback()
+    return
+  end
+
+  Engine.generate_one_stage(row, col, true, 0, function(suggestions)
+    -- We skip the suggestion where the first element is empty, as nvim-cmp trim the completion item
+    -- Ref: `lazy/nvim-cmp/lua/cmp/entry.lua`
+    if not suggestions or #suggestions == 0 or suggestions[1] == '' then
+      callback()
+      return
+    end
+    local line = context.line
+    local character = line:sub(context.bounds.start_col, context.bounds.end_col)
+    local info = {
+      triggerCharacter = context.trigger.character,
+      line = line,
+      character = character,
+      -- reason = request.option.reason,
+    }
+    Log.debug('Source(blink) request: {}', info)
+    local response = convert_to_lsp_completion_response(line, character, suggestions)
+    -- Log.debug('LSP CompletionResponse: {}', response)
+    callback(response)
+    -- callback()
+  end, function()
+    callback()
+  end)
+end
+
+--- Resolve ---
+
+function blink:resolve(item, callback)
+  Log.debug('Source(blink) item: {}', item)
+
+  local resolved_item = vim.deepcopy(item)
+  resolved_item.detail = item.insertText
+  resolved_item.documentation = {
+    kind = 'markdown',
+    value = item.description,
+  }
+  Log.debug('Source(blink) resolved: {}', resolved_item)
+  callback(resolved_item)
+end
+
+function blink.setup() end
+
+return blink

--- a/lua/fittencode/sources/blink/init.lua
+++ b/lua/fittencode/sources/blink/init.lua
@@ -3,7 +3,7 @@ local Config = require('fittencode.config')
 local Engine = require('fittencode.engines.inline')
 local Log = require('fittencode.log')
 local Sources = require('fittencode.sources')
---@Class blink.cmp.Source
+-- @Class blink.cmp.Source
 local blink = {}
 
 -- Use `get_word` so that the word is the same as in `core.confirm`
@@ -12,7 +12,6 @@ local blink = {}
 ---@param suggestions string[]
 ---@return lsp.CompletionResponse?
 local function convert_to_lsp_completion_response(line, character, suggestions)
-  -- cursor_before_line = cursor_before_line or ''
   local LABEL_LIMIT = 80
   local text = character .. table.concat(suggestions, '\n')
   local first = character .. suggestions[1]
@@ -48,13 +47,13 @@ function blink:get_completions(context, callback)
     end
     local line = context.line
     local character = line:sub(context.bounds.start_col, context.bounds.end_col)
-    local info = {
-      triggerCharacter = context.trigger.character,
-      line = line,
-      character = character,
-      -- reason = request.option.reason,
-    }
-    Log.debug('Source(blink) request: {}', info)
+    -- local info = {
+    --   triggerCharacter = context.trigger.character,
+    --   line = line,
+    --   character = character,
+    --   -- reason = request.option.reason,
+    -- }
+    -- Log.debug('Source(blink) request: {}', info)
     local response = convert_to_lsp_completion_response(line, character, suggestions)
     -- Log.debug('LSP CompletionResponse: {}', response)
     callback(response)
@@ -67,7 +66,7 @@ end
 --- Resolve ---
 
 function blink:resolve(item, callback)
-  Log.debug('Source(blink) item: {}', item)
+  -- Log.debug('Source(blink) item: {}', item)
 
   local resolved_item = vim.deepcopy(item)
   resolved_item.detail = item.insertText
@@ -75,7 +74,7 @@ function blink:resolve(item, callback)
     kind = 'markdown',
     value = item.description,
   }
-  Log.debug('Source(blink) resolved: {}', resolved_item)
+  -- Log.debug('Source(blink) resolved: {}', resolved_item)
   callback(resolved_item)
 end
 

--- a/lua/fittencode/sources/init.lua
+++ b/lua/fittencode/sources/init.lua
@@ -11,6 +11,9 @@ local builtins = {
   ['cmp'] = function()
     require('fittencode.sources.cmp').setup()
   end,
+  ['blink'] = function()
+    require('fittencode.sources.blink').setup()
+  end,
 }
 
 function M.is_available()


### PR DESCRIPTION
i switch my autocompletion plugin from nvim-cmp to blink, because when i use cmp it's always a bit laggy, but **blink.cmp is beta quality**, so, I'm not sure if this feature should be added to the master branch or not. i need you to evaluate it.
thks!