### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ use {
     -- Enable source completion.
     enable = true,
     -- engine support nvim-cmp and blink.cmp
-    engine = "cmp" -- "cmp" | "blink"
+    engine = "cmp", -- "cmp" | "blink"
     -- trigger characters for source completion.
     -- Available options:
     -- * A  list of characters like {'a', 'b', 'c', ...}


### PR DESCRIPTION
Trivial matter. There is a comma missing in the default config, which would cause it to be buggy should someone just copy-paste it.