### PR TITLE
Allow setting custom icon in blink-cmp

### DIFF
--- a/lua/fittencode/sources/blink/init.lua
+++ b/lua/fittencode/sources/blink/init.lua
@@ -28,6 +28,7 @@ local function convert_to_lsp_completion_response(line, character, suggestions)
 end
 
 function blink:new()
+  require("blink.cmp.types").CompletionItemKind['FittenCode'] = 'FittenCode'
   return setmetatable({}, { __index = blink })
 end
 


### PR DESCRIPTION
Blink-cmp supports setting custom kind_icons via
`appearance.kind_icons`. However, merely adding "FittenCode" to the table would not suffice because blink does not recognize this kind. We have to manually register the kind name.